### PR TITLE
chore: フロントエンド開発サーバーの設定を調整

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-	/* config options here */
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"dev": "next dev --turbopack",
+		"dev": "next dev -p 3000 --turbopack",
 		"build": "next build --turbopack",
 		"type-check": "tsc --noEmit",
 		"check": "biome check . --fix"


### PR DESCRIPTION
## 概要
フロントエンド開発サーバーの設定を調整しました。

## 変更内容
- `next.config.ts` のコメントを簡潔化
- 開発サーバーのポートを明示的に3000番に指定（`pnpm dev` コマンド）

## 変更理由
- コード品質の向上
- 開発環境の明確化（デフォルトポートの明示）

## テスト
- [x] `pnpm dev` でポート3000番でサーバーが起動することを確認
- [x] `pnpm build` でビルドが成功することを確認
- [x] `pnpm type-check` で型エラーがないことを確認
- [x] `pnpm check` でBiomeチェックが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)