### PR TITLE
feat: implement gateway API with order uploading functionality

### DIFF
--- a/backend/deploy/nginx/nginx.conf
+++ b/backend/deploy/nginx/nginx.conf
@@ -12,6 +12,10 @@ http {
         server gateway-ws:8080;
     }
 
+    upstream gateway_api {
+        server gateway-api:8080;
+    }
+
     server {
         listen 80;
 
@@ -22,6 +26,15 @@ http {
             proxy_set_header Connection "upgrade";
             proxy_set_header Host $host;
             proxy_pass http://gateway_ws;
+        }
+
+        # REST API path
+        location /v1/ {
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_pass http://gateway_api;
         }
 
         # Healthz of edge itself

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   gateway-api:
     build:
@@ -7,8 +6,6 @@ services:
     image: local/gateway-api:dev
     environment:
       - PORT=8080
-    ports:
-      - "8081:8080"
   kakigori-ws:
     build:
       context: .
@@ -16,8 +13,6 @@ services:
     image: local/kakigori-ws:dev
     environment:
       - PORT=50051
-    ports:
-      - "50051:50051"
   gateway-ws:
     build:
       context: .
@@ -34,6 +29,7 @@ services:
       - "8080:80"
     depends_on:
       - gateway-ws
+      - gateway-api
     volumes:
       - ./deploy/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
 

--- a/backend/pkg/httpclient/httpclient.go
+++ b/backend/pkg/httpclient/httpclient.go
@@ -1,0 +1,8 @@
+package httpclient
+
+import "net/http"
+
+// HTTPClient represents the subset of http.Client we rely on, for easier testing.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}

--- a/backend/pkg/testhttpclient/test_http_helpers_test.go
+++ b/backend/pkg/testhttpclient/test_http_helpers_test.go
@@ -1,0 +1,13 @@
+package testhttpclient
+
+import "net/http"
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+type httpClient struct{ rt http.RoundTripper }
+
+func (c *httpClient) Do(req *http.Request) (*http.Response, error) {
+	return c.rt.RoundTrip(req)
+}

--- a/backend/pkg/testhttpclient/testhttpclient.go
+++ b/backend/pkg/testhttpclient/testhttpclient.go
@@ -1,0 +1,19 @@
+package testhttpclient
+
+import "net/http"
+
+// RoundTripperFunc is an adapter to allow the use of
+// ordinary functions as http.RoundTripper.
+type RoundTripperFunc func(*http.Request) (*http.Response, error)
+
+// RoundTrip calls f(r).
+func (f RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// Client is a minimal HTTP client that delegates to the provided RoundTripper.
+// It satisfies interfaces that only need Do(*http.Request) (*http.Response, error).
+type Client struct{ RT http.RoundTripper }
+
+// Do implements the minimal HTTP client interface.
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	return c.RT.RoundTrip(req)
+}

--- a/backend/services/gateway-api/cmd/server/main.go
+++ b/backend/services/gateway-api/cmd/server/main.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	upstreamBaseURL = "https://kakigori-api.fly.dev"
-	storeID         = "HKWZRTNL"
+	baseURL = "https://kakigori-api.fly.dev"
+	storeID = "HKWZRTNL"
 )
 
 func main() {
@@ -24,21 +24,27 @@ func main() {
 	}
 
 	// DI(Usecase)
-	menuUsecase := usecase.NewMenuUsecase(upstreamBaseURL)
+	menuUsecase := usecase.NewMenuUsecase(baseURL)
+	orderUsecase := usecase.NewOrderUsecase(baseURL)
 
 	// DI(Handler)
 	menuHandler := handler.NewMenuHandler(menuUsecase)
+	orderHandler := handler.NewOrderHandler(orderUsecase)
 
 	// Routing
 	e := echo.New()
-	e.GET("/api/healthz", func(c echo.Context) error {
+	e.GET("/v1/healthz", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 	})
 	e.GET("/swagger.yaml", func(c echo.Context) error {
-		return c.File("/api/swagger/gateway-api.yml")
+		return c.File("/v1/swagger/gateway-api.yml")
 	})
-	e.GET("/api/v1/stores/menu", func(c echo.Context) error {
+	e.GET("/v1/stores/menu", func(c echo.Context) error {
 		menuHandler.GetMenu(c.Response().Writer, c.Request(), storeID)
+		return nil
+	})
+	e.POST("/v1/stores/orders", func(c echo.Context) error {
+		orderHandler.PostOrders(c.Response().Writer, c.Request(), storeID)
 		return nil
 	})
 

--- a/backend/services/gateway-api/internal/interface/handler/order_handler.go
+++ b/backend/services/gateway-api/internal/interface/handler/order_handler.go
@@ -1,0 +1,55 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"chantingkakigori/services/gateway-api/internal/usecase"
+)
+
+// OrderHandler handles order-related HTTP requests.
+type OrderHandler struct {
+	Usecase usecase.OrderUsecase
+}
+
+func NewOrderHandler(u usecase.OrderUsecase) *OrderHandler { return &OrderHandler{Usecase: u} }
+
+// PostOrders processes POST /v1/stores/orders requests.
+func (h *OrderHandler) PostOrders(w http.ResponseWriter, r *http.Request, storeID string) {
+	ctx := r.Context()
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+	}
+
+	var body struct {
+		MenuItemID string `json:"menu_item_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.MenuItemID == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":   "Bad Request",
+			"message": "Invalid request body",
+		})
+		return
+	}
+
+	order, err := h.Usecase.PostOrder(ctx, storeID, body.MenuItemID)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":   "Bad Gateway",
+			"message": err.Error(),
+		})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(order)
+}

--- a/backend/services/gateway-api/internal/usecase/menu.go
+++ b/backend/services/gateway-api/internal/usecase/menu.go
@@ -3,30 +3,25 @@ package usecase
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"time"
 
+	httpclient "chantingkakigori/pkg/httpclient"
 	openapi "chantingkakigori/services/gateway-api/internal/swagger"
 )
 
-// HTTPClient represents the subset of http.Client we rely on, for easier testing.
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
 // MenuUsecase fetches store menus from the upstream API.
-type MenuUsecase struct {
+type MenuClient struct {
 	BaseURL string
-	Client  HTTPClient
+	Client  httpclient.HTTPClient
 }
 
 // NewMenuUsecase creates a new MenuUsecase with sane defaults.
-func NewMenuUsecase(baseURL string) *MenuUsecase {
-	return &MenuUsecase{
+func NewMenuUsecase(baseURL string) *MenuClient {
+	return &MenuClient{
 		BaseURL: baseURL,
 		Client: &http.Client{
 			Timeout: 10 * time.Second,
@@ -41,11 +36,7 @@ type MenuFetcher interface {
 
 // FetchMenu retrieves menu items for the given storeID from upstream and converts them
 // into the swagger-generated types.
-func (u *MenuUsecase) FetchMenu(ctx context.Context, storeID string) ([]openapi.MenuItem, error) {
-	if storeID == "" {
-		return nil, errors.New("storeID is required")
-	}
-
+func (u *MenuClient) FetchMenu(ctx context.Context, storeID string) ([]openapi.MenuItem, error) {
 	base, err := url.Parse(u.BaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid base url: %w", err)

--- a/backend/services/gateway-api/internal/usecase/menu_test.go
+++ b/backend/services/gateway-api/internal/usecase/menu_test.go
@@ -6,20 +6,12 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	testhttpclient "chantingkakigori/pkg/testhttpclient"
 )
 
-type roundTripperFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
-
-type httpClient struct{ rt http.RoundTripper }
-
-func (c *httpClient) Do(req *http.Request) (*http.Response, error) {
-	return c.rt.RoundTrip(req)
-}
-
-func TestFetchMenu_Success(t *testing.T) {
-	uc := &MenuUsecase{BaseURL: "https://example", Client: &httpClient{rt: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+func TestGetMenu_Success(t *testing.T) {
+	uc := &MenuClient{BaseURL: "https://example", Client: &testhttpclient.Client{RT: testhttpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		if r.URL.Path != "/v1/stores/HKWZRTNL/menu" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
@@ -39,8 +31,8 @@ func TestFetchMenu_Success(t *testing.T) {
 	}
 }
 
-func TestFetchMenu_UpstreamError(t *testing.T) {
-	uc := &MenuUsecase{BaseURL: "https://example", Client: &httpClient{rt: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+func TestGetMenu_UpstreamError(t *testing.T) {
+	uc := &MenuClient{BaseURL: "https://example", Client: &testhttpclient.Client{RT: testhttpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: 500, Body: io.NopCloser(strings.NewReader("oops")), Header: make(http.Header)}, nil
 	})}}
 

--- a/backend/services/gateway-api/internal/usecase/order.go
+++ b/backend/services/gateway-api/internal/usecase/order.go
@@ -1,0 +1,125 @@
+package usecase
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	httpclient "chantingkakigori/pkg/httpclient"
+	openapi "chantingkakigori/services/gateway-api/internal/swagger"
+)
+
+// OrderClient fetches store orders from the upstream API.
+type OrderClient struct {
+	BaseURL string
+	Client  httpclient.HTTPClient
+}
+
+// NewMenuUsecase creates a new MenuUsecase with sane defaults.
+func NewOrderUsecase(baseURL string) *OrderClient {
+	return &OrderClient{
+		BaseURL: baseURL,
+		Client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+type OrderUsecase interface {
+	PostOrder(ctx context.Context, storeID string, menuItemID string) (openapi.OrderResponse, error)
+}
+
+func (u *OrderClient) PostOrder(ctx context.Context, storeID string, menuItemID string) (openapi.OrderResponse, error) {
+	base, err := url.Parse(u.BaseURL)
+	if err != nil {
+		return openapi.OrderResponse{}, fmt.Errorf("invalid base url: %w", err)
+	}
+	base.Path = fmt.Sprintf("/v1/stores/%s/orders", url.PathEscape(storeID))
+
+	payload := map[string]string{"menu_item_id": menuItemID}
+	buf := &bytes.Buffer{}
+	if err := json.NewEncoder(buf).Encode(payload); err != nil {
+		return openapi.OrderResponse{}, fmt.Errorf("encode request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base.String(), buf)
+	if err != nil {
+		return openapi.OrderResponse{}, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := u.Client.Do(req)
+	if err != nil {
+		return openapi.OrderResponse{}, fmt.Errorf("upstream request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		// Read a small portion of the body for diagnostics
+		limited := io.LimitReader(resp.Body, 1024)
+		b, _ := io.ReadAll(limited)
+		return openapi.OrderResponse{}, fmt.Errorf("upstream returned status %d: %s", resp.StatusCode, string(b))
+	}
+
+	// Read entire body once to allow trying multiple shapes
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return openapi.OrderResponse{}, fmt.Errorf("read upstream response: %w", err)
+	}
+
+	// Shape 1: wrapper {"orders": [{...}]}
+	var wrapped struct {
+		Orders []struct {
+			Id          string                      `json:"id"`
+			MenuItemId  string                      `json:"menu_item_id"`
+			MenuName    string                      `json:"menu_name"`
+			OrderNumber int                         `json:"order_number"`
+			Status      openapi.OrderResponseStatus `json:"status"`
+		} `json:"orders"`
+	}
+	if err := json.Unmarshal(raw, &wrapped); err == nil && len(wrapped.Orders) > 0 {
+		first := wrapped.Orders[0]
+		id := first.Id
+		menuItemId := first.MenuItemId
+		menuName := first.MenuName
+		orderNumber := first.OrderNumber
+		status := first.Status
+		return openapi.OrderResponse{
+			Id:          &id,
+			MenuItemId:  &menuItemId,
+			MenuName:    &menuName,
+			OrderNumber: &orderNumber,
+			Status:      &status,
+		}, nil
+	}
+
+	// Shape 2: single object
+	var single struct {
+		Id          string                      `json:"id"`
+		MenuItemId  string                      `json:"menu_item_id"`
+		MenuName    string                      `json:"menu_name"`
+		OrderNumber int                         `json:"order_number"`
+		Status      openapi.OrderResponseStatus `json:"status"`
+	}
+	if err := json.Unmarshal(raw, &single); err == nil && single.Id != "" {
+		id := single.Id
+		menuItemId := single.MenuItemId
+		menuName := single.MenuName
+		orderNumber := single.OrderNumber
+		status := single.Status
+		return openapi.OrderResponse{
+			Id:          &id,
+			MenuItemId:  &menuItemId,
+			MenuName:    &menuName,
+			OrderNumber: &orderNumber,
+			Status:      &status,
+		}, nil
+	}
+
+	return openapi.OrderResponse{}, fmt.Errorf("empty or unrecognized upstream response")
+}

--- a/backend/services/gateway-api/internal/usecase/order_test.go
+++ b/backend/services/gateway-api/internal/usecase/order_test.go
@@ -1,0 +1,55 @@
+package usecase
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	testhttpclient "chantingkakigori/pkg/testhttpclient"
+)
+
+func TestPostOrder_Success(t *testing.T) {
+	uc := &OrderClient{BaseURL: "https://example", Client: &testhttpclient.Client{RT: testhttpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/v1/stores/HKWZRTNL/orders" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		body := `{"id":"o-1","menu_item_id":"giiku-sai","menu_name":"x","order_number":1,"status":"pending"}`
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+	})}}
+
+	order, err := uc.PostOrder(context.Background(), "HKWZRTNL", "giiku-sai")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if order.Id == nil || *order.Id != "o-1" {
+		t.Fatalf("unexpected id: %#v", order.Id)
+	}
+	if order.MenuItemId == nil || *order.MenuItemId != "giiku-sai" {
+		t.Fatalf("unexpected menu_item_id: %#v", order.MenuItemId)
+	}
+	if order.MenuName == nil || *order.MenuName != "x" {
+		t.Fatalf("unexpected menu_name: %#v", order.MenuName)
+	}
+	if order.OrderNumber == nil || *order.OrderNumber != 1 {
+		t.Fatalf("unexpected order_number: %#v", order.OrderNumber)
+	}
+	if order.Status == nil || string(*order.Status) != "pending" {
+		t.Fatalf("unexpected status: %#v", order.Status)
+	}
+}
+
+func TestPostOrder_UpstreamError(t *testing.T) {
+	uc := &OrderClient{BaseURL: "https://example", Client: &testhttpclient.Client{RT: testhttpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 500, Body: io.NopCloser(strings.NewReader("oops")), Header: make(http.Header)}, nil
+	})}}
+
+	_, err := uc.PostOrder(context.Background(), "HKWZRTNL", "giiku-sai")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}

--- a/backend/services/gateway-ws/Dockerfile
+++ b/backend/services/gateway-ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /app
 COPY go.mod ./
 RUN go mod download

--- a/backend/services/kakigori-ws/Dockerfile
+++ b/backend/services/kakigori-ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /app
 COPY go.mod .
 RUN go mod download


### PR DESCRIPTION
## Overview
ラムダさんの注文をするAPIを叩くエンドポイントの実装をしました

## How To Use
以下のコマンドを叩きます
```bash
curl -X POST http://localhost:8080/v1/stores/orders -H 'content-type: application/json' -d '{"menu_item_id":"giiku-sai"}'
```
実行結果
```json
{"id":"HKWZRTNL-6","menu_item_id":"giiku-sai","menu_name":"技育祭な いちご味","order_number":6,"status":"pending"}
```
## Commits
- **feat: implement gateway API with order uploading functionality**
