### PR TITLE
feat(gateway-api): add endpoint to retrieve order by ID and refactor menu fetching logic

### DIFF
--- a/backend/services/gateway-api/cmd/server/main.go
+++ b/backend/services/gateway-api/cmd/server/main.go
@@ -47,6 +47,10 @@ func main() {
 		orderHandler.PostOrders(c.Response().Writer, c.Request(), storeID)
 		return nil
 	})
+	e.GET("/v1/stores/orders/:order_id", func(c echo.Context) error {
+		orderHandler.GetOrderByID(c.Response().Writer, c.Request(), storeID, c.Param("order_id"))
+		return nil
+	})
 
 	srv := &http.Server{
 		Addr:              ":" + httpPort,

--- a/backend/services/gateway-api/internal/interface/handler/menu_handler_test.go
+++ b/backend/services/gateway-api/internal/interface/handler/menu_handler_test.go
@@ -10,22 +10,22 @@ import (
 	openapi "chantingkakigori/services/gateway-api/internal/swagger"
 )
 
-type fakeFetcher struct {
+type fakeMenuFetcher struct {
 	items []openapi.MenuItem
 	err   error
 }
 
-func (f fakeFetcher) FetchMenu(_ context.Context, _ string) ([]openapi.MenuItem, error) {
-	return f.items, f.err
+func (f fakeMenuFetcher) FetchMenu(_ context.Context, _ string) (*[]openapi.MenuItem, error) {
+	return &f.items, f.err
 }
 
 func TestMenuHandler_BadRequestWhenNoStoreID(t *testing.T) {
 	t.Setenv("STORE_ID", "")
-	h := NewMenuHandler(fakeFetcher{})
+	h := NewMenuHandler(fakeMenuFetcher{items: []openapi.MenuItem{}, err: nil})
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/stores/menu", nil)
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
+	h.GetMenu(rec, req, "")
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rec.Code)
@@ -37,7 +37,7 @@ func TestMenuHandler_Success(t *testing.T) {
 	name := "x"
 	desc := "y"
 	items := []openapi.MenuItem{{Id: &id, Name: &name, Description: &desc}}
-	h := NewMenuHandler(fakeFetcher{items: items})
+	h := NewMenuHandler(fakeMenuFetcher{items: items})
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/stores/menu", nil)
 	rec := httptest.NewRecorder()

--- a/backend/services/gateway-api/internal/interface/handler/order_handler_test.go
+++ b/backend/services/gateway-api/internal/interface/handler/order_handler_test.go
@@ -1,0 +1,159 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	openapi "chantingkakigori/services/gateway-api/internal/swagger"
+	"chantingkakigori/services/gateway-api/internal/usecase"
+)
+
+type fakeOrderUsecase struct {
+	order   openapi.OrderResponse
+	getByID *usecase.GetOrderByIDResponse
+	err     error
+}
+
+func (f fakeOrderUsecase) PostOrder(_ context.Context, _ string, _ string) (*openapi.OrderResponse, error) {
+	return &f.order, f.err
+}
+
+func (f fakeOrderUsecase) GetOrderByID(_ context.Context, _ string, _ string) (*usecase.GetOrderByIDResponse, error) {
+	return f.getByID, f.err
+}
+
+func TestOrderHandler_BadRequest_InvalidBody(t *testing.T) {
+	h := NewOrderHandler(fakeOrderUsecase{})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/stores/HKWZRTNL/orders", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	h.PostOrders(rec, req, "HKWZRTNL")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json, got %s", ct)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["error"] != "Bad Request" || body["message"] != "Invalid request body" {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+}
+
+func TestOrderHandler_PostOrders_Success(t *testing.T) {
+	id := "o-1"
+	menuItemID := "giiku-sai"
+	menuName := "x"
+	orderNumber := 1
+	status := openapi.Pending
+	uc := fakeOrderUsecase{order: openapi.OrderResponse{
+		Id:          &id,
+		MenuItemId:  &menuItemID,
+		MenuName:    &menuName,
+		OrderNumber: &orderNumber,
+		Status:      &status,
+	}}
+
+	h := NewOrderHandler(uc)
+	req := httptest.NewRequest(http.MethodPost, "/v1/stores/HKWZRTNL/orders", strings.NewReader(`{"menu_item_id":"giiku-sai"}`))
+	rec := httptest.NewRecorder()
+	h.PostOrders(rec, req, "HKWZRTNL")
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json, got %s", ct)
+	}
+
+	var resp openapi.OrderResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Id == nil || *resp.Id != id {
+		t.Fatalf("unexpected id: %#v", resp.Id)
+	}
+	if resp.MenuItemId == nil || *resp.MenuItemId != menuItemID {
+		t.Fatalf("unexpected menu_item_id: %#v", resp.MenuItemId)
+	}
+}
+
+func TestOrderHandler_PostOrders_UpstreamError(t *testing.T) {
+	h := NewOrderHandler(fakeOrderUsecase{err: errors.New("oops")})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/stores/HKWZRTNL/orders", strings.NewReader(`{"menu_item_id":"giiku-sai"}`))
+	rec := httptest.NewRecorder()
+	h.PostOrders(rec, req, "HKWZRTNL")
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json, got %s", ct)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["error"] != "Bad Gateway" || body["message"] != "oops" {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+}
+
+func TestOrderHandler_GetOrderByID_Success(t *testing.T) {
+	id := "o-1"
+	h := NewOrderHandler(fakeOrderUsecase{getByID: &usecase.GetOrderByIDResponse{Id: &id}})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/stores/HKWZRTNL/orders/o-1", nil)
+	rec := httptest.NewRecorder()
+	h.GetOrderByID(rec, req, "HKWZRTNL", "o-1")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json, got %s", ct)
+	}
+
+	var resp usecase.GetOrderByIDResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Id == nil || *resp.Id != "o-1" {
+		t.Fatalf("unexpected id: %#v", resp.Id)
+	}
+}
+
+func TestOrderHandler_GetOrderByID_UpstreamError(t *testing.T) {
+	h := NewOrderHandler(fakeOrderUsecase{err: errors.New("oops")})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/stores/HKWZRTNL/orders/o-1", nil)
+	rec := httptest.NewRecorder()
+	h.GetOrderByID(rec, req, "HKWZRTNL", "o-1")
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json, got %s", ct)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["error"] != "Bad Gateway" || body["message"] != "oops" {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+}

--- a/backend/services/gateway-api/internal/usecase/menu.go
+++ b/backend/services/gateway-api/internal/usecase/menu.go
@@ -31,12 +31,11 @@ func NewMenuUsecase(baseURL string) *MenuClient {
 
 // MenuFetcher is the interface used by handlers to fetch menu items.
 type MenuFetcher interface {
-	FetchMenu(ctx context.Context, storeID string) ([]openapi.MenuItem, error)
+	FetchMenu(ctx context.Context, storeID string) (*[]openapi.MenuItem, error)
 }
 
-// FetchMenu retrieves menu items for the given storeID from upstream and converts them
-// into the swagger-generated types.
-func (u *MenuClient) FetchMenu(ctx context.Context, storeID string) ([]openapi.MenuItem, error) {
+// FetchMenu retrieves menu items for the given storeID from upstream and converts them into the swagger-generated types.
+func (u *MenuClient) FetchMenu(ctx context.Context, storeID string) (*[]openapi.MenuItem, error) {
 	base, err := url.Parse(u.BaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid base url: %w", err)
@@ -84,5 +83,5 @@ func (u *MenuClient) FetchMenu(ctx context.Context, storeID string) ([]openapi.M
 			Description: &desc,
 		})
 	}
-	return items, nil
+	return &items, nil
 }

--- a/backend/services/gateway-api/internal/usecase/menu_test.go
+++ b/backend/services/gateway-api/internal/usecase/menu_test.go
@@ -23,11 +23,11 @@ func TestGetMenu_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(items) != 1 {
-		t.Fatalf("expected 1 item, got %d", len(items))
+	if len(*items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(*items))
 	}
-	if items[0].Id == nil || *items[0].Id != "giiku-sai" {
-		t.Fatalf("unexpected id: %#v", items[0].Id)
+	if (*items)[0].Id == nil || *(*items)[0].Id != "giiku-sai" {
+		t.Fatalf("unexpected id: %#v", (*items)[0].Id)
 	}
 }
 


### PR DESCRIPTION
## Overview
ラムダさんが作成されたOrderIDをパスパラメータにセットすると注文を取得できるAPIを叩くエンドポイントを作成しました

## How To Use
叩き方
```bash
curl -X GET http://localhost:8080/v1/stores/orders/XXXXXXXX-0 -H 'content-type: application/json' 
```
レスポンス
```json
{
    "id": "XXXXXXXX-0",
    "menu_item_id": "giiku-sai",
    "menu_name": "技育祭な いちご味",
    "order_number": 8
}
```


## Commits
- **feat(gateway-api): add endpoint to retrieve order by ID and refactor menu fetching logic**