### PR TITLE
feat(gateway-api): define transcript swagger

### DIFF
--- a/backend/api/swagger/gateway-api.yml
+++ b/backend/api/swagger/gateway-api.yml
@@ -6,11 +6,41 @@ info:
 servers:
   - url: http://localhost:8080
 paths:
+  /api/v1/transcript:
+    post:
+      summary: Compute similarity between provided text and speech in audio
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SimilarityRequest"
+            example:
+              audio_base64: UklGRiQAAABXQVZFZm10IBIAAAABAAEAESsAACJWAAACABAAZGF0YQAAAA==
+              text: こんにちは
+      responses:
+        "200":
+          description: Similarity score
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimilarityResponse"
+              example:
+                similarity: 0.87
+        "400":
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Bad Request
+                message: Invalid request body
   /api/v1/stores/menu:
     get:
       summary: Get menu for a store
       responses:
-        '200':
+        "200":
           description: Menu list
           content:
             application/json:
@@ -20,7 +50,7 @@ paths:
                   menu:
                     type: array
                     items:
-                      $ref: '#/components/schemas/MenuItem'
+                      $ref: "#/components/schemas/MenuItem"
               example:
                 menu:
                   - id: giiku-sai
@@ -44,24 +74,24 @@ paths:
             example:
               menu_item_id: giiku-sai
       responses:
-        '201':
+        "201":
           description: Order created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrderResponse'
+                $ref: "#/components/schemas/OrderResponse"
               example:
                 id: store-001-1
                 menu_item_id: giiku-sai
                 menu_name: 技育祭な いちご味
                 status: pending
                 order_number: 1
-        '400':
+        "400":
           description: Invalid input or menu_item_id not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               examples:
                 invalidBody:
                   summary: Invalid request body
@@ -84,28 +114,45 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Order found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrderResponse'
+                $ref: "#/components/schemas/OrderResponse"
               example:
                 id: store-001-1
                 menu_item_id: giiku-sai
                 menu_name: 技育祭な いちご味
                 order_number: 1
-        '400':
+        "400":
           description: Invalid order ID format
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
               example:
                 error: Bad Request
                 message: Invalid order ID format
 components:
   schemas:
+    SimilarityRequest:
+      type: object
+      required: [audio_base64, text]
+      properties:
+        audio_base64:
+          type: string
+          description: Base64-encoded audio data (required MP3 file)
+        text:
+          type: string
+          description: Text to compare against transcribed audio(文字起こし正解のテキスト)
+    SimilarityResponse:
+      type: object
+      properties:
+        similarity:
+          type: number
+          format: float
+          description: "Similarity score between 0 and 1 (1: perfect match, 0: no match)"
     MenuItem:
       type: object
       properties:

--- a/backend/services/gateway-api/internal/swagger/gateway-api.gen.go
+++ b/backend/services/gateway-api/internal/swagger/gateway-api.gen.go
@@ -35,6 +35,21 @@ type OrderResponse struct {
 // OrderResponseStatus defines model for OrderResponse.Status.
 type OrderResponseStatus string
 
+// SimilarityRequest defines model for SimilarityRequest.
+type SimilarityRequest struct {
+	// AudioBase64 Base64-encoded audio data (required MP3 file)
+	AudioBase64 string `json:"audio_base64"`
+
+	// Text Text to compare against transcribed audio(文字起こし正解のテキスト)
+	Text string `json:"text"`
+}
+
+// SimilarityResponse defines model for SimilarityResponse.
+type SimilarityResponse struct {
+	// Similarity Similarity score between 0 and 1 (1: perfect match, 0: no match)
+	Similarity *float32 `json:"similarity,omitempty"`
+}
+
 // PostApiV1StoresOrdersJSONBody defines parameters for PostApiV1StoresOrders.
 type PostApiV1StoresOrdersJSONBody struct {
 	MenuItemId *string `json:"menu_item_id,omitempty"`
@@ -42,3 +57,6 @@ type PostApiV1StoresOrdersJSONBody struct {
 
 // PostApiV1StoresOrdersJSONRequestBody defines body for PostApiV1StoresOrders for application/json ContentType.
 type PostApiV1StoresOrdersJSONRequestBody PostApiV1StoresOrdersJSONBody
+
+// PostApiV1TranscriptJSONRequestBody defines body for PostApiV1Transcript for application/json ContentType.
+type PostApiV1TranscriptJSONRequestBody = SimilarityRequest


### PR DESCRIPTION
## Overview
文字起こし用のエンドポイントのSwaggerを作成しました

## discussion
@Yuma-Satake 
文字起こしのエンドポイントは現状RESTAPIにしているけどWebSocketがいいかな？

RESTAPIにした理由はフロント側で録音開始と録音終了のトリガーを決めてMP3としてBase64にエンコードする処理をしてほしい...といった処理に時間がかかるかなぁと思い非同期処理にする意味があるんでしょうか？と思ったからです...

WebSocketにする利点はわかんなかった


結局，ある程度声を出す→ https://github.com/JavaLangRuntimeException/chanting_kakigori/pull/2 && 詠唱の文字列がある程度あっている → #このPR 
ならば注文可能
という認識で詠唱部分はあってるかな？
(バックエンドでは数字(音の大きさと詠唱文字の一致度)のみ渡すのでフロントエンドで注文可能の閾値を決める方針です)

## How To Use
どうぞmake swagger-genをしてください

## Commits
- **feat(gateway-api): define transcript swagger**
