### PR TITLE
refactor(gateway-api): update API endpoints to use /api prefix for consistency

### DIFF
--- a/backend/deploy/nginx/nginx.conf
+++ b/backend/deploy/nginx/nginx.conf
@@ -42,7 +42,7 @@ http {
         }
 
         # REST API path
-        location /v1/ {
+        location /api {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/backend/services/gateway-api/cmd/server/main.go
+++ b/backend/services/gateway-api/cmd/server/main.go
@@ -33,21 +33,21 @@ func main() {
 
 	// Routing
 	e := echo.New()
-	e.GET("/v1/healthz", func(c echo.Context) error {
+	e.GET("/api/v1/healthz", func(c echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 	})
-	e.GET("/swagger.yaml", func(c echo.Context) error {
+	e.GET("/api/v1/swagger.yaml", func(c echo.Context) error {
 		return c.File("/v1/swagger/gateway-api.yml")
 	})
-	e.GET("/v1/stores/menu", func(c echo.Context) error {
+	e.GET("/api/v1/stores/menu", func(c echo.Context) error {
 		menuHandler.GetMenu(c.Response().Writer, c.Request(), storeID)
 		return nil
 	})
-	e.POST("/v1/stores/orders", func(c echo.Context) error {
+	e.POST("/api/v1/stores/orders", func(c echo.Context) error {
 		orderHandler.PostOrders(c.Response().Writer, c.Request(), storeID)
 		return nil
 	})
-	e.GET("/v1/stores/orders/:order_id", func(c echo.Context) error {
+	e.GET("/api/v1/stores/orders/:order_id", func(c echo.Context) error {
 		orderHandler.GetOrderByID(c.Response().Writer, c.Request(), storeID, c.Param("order_id"))
 		return nil
 	})

--- a/backend/services/gateway-api/internal/interface/handler/order_handler.go
+++ b/backend/services/gateway-api/internal/interface/handler/order_handler.go
@@ -41,6 +41,32 @@ func (h *OrderHandler) PostOrders(w http.ResponseWriter, r *http.Request, storeI
 	order, err := h.Usecase.PostOrder(ctx, storeID, body.MenuItemID)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
+		// Map upstream status codes when possible
+		if ue, ok := err.(*usecase.UpstreamError); ok {
+			switch ue.StatusCode {
+			case http.StatusBadRequest:
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"error":   "Bad Request",
+					"message": ue.Body,
+				})
+				return
+			case http.StatusNotFound:
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"error":   "Not Found",
+					"message": ue.Body,
+				})
+				return
+			default:
+				w.WriteHeader(http.StatusBadGateway)
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"error":   "Bad Gateway",
+					"message": ue.Body,
+				})
+				return
+			}
+		}
 		w.WriteHeader(http.StatusBadGateway)
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"error":   "Bad Gateway",
@@ -65,6 +91,31 @@ func (h *OrderHandler) GetOrderByID(w http.ResponseWriter, r *http.Request, stor
 	order, err := h.Usecase.GetOrderByID(ctx, storeID, orderID)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
+		if ue, ok := err.(*usecase.UpstreamError); ok {
+			switch ue.StatusCode {
+			case http.StatusBadRequest:
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"error":   "Bad Request",
+					"message": ue.Body,
+				})
+				return
+			case http.StatusNotFound:
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"error":   "Not Found",
+					"message": ue.Body,
+				})
+				return
+			default:
+				w.WriteHeader(http.StatusBadGateway)
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"error":   "Bad Gateway",
+					"message": ue.Body,
+				})
+				return
+			}
+		}
 		w.WriteHeader(http.StatusBadGateway)
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"error":   "Bad Gateway",


### PR DESCRIPTION
## Overview
swaggerに合わせて/apiをルーティングに追加するようにしました

## How To Use
メニュー取得
```json
curl -X GET http://localhost:8080/api/v1/stores/menu -H 'content-type: application/json'
{"menu":[{"description":"技育祭をイメージしたいちご味のかき氷","id":"giiku-sai","name":"技育祭な いちご味"},{"description":"技育博をイメージしたメロン味のかき氷","id":"giiku-haku","name":"技育博な メロン味"},{"description":"技育展をイメージしたブルーハワイ味のかき氷","id":"giiku-ten","name":"技育展な ブルーハワイ味"},{"description":"技育CAMPをイメージしたオレンジ味のかき氷","id":"giiku-camp","name":"技育CAMPな オレンジ味"}]}
```
注文API
```json
curl -X POST http://localhost:8080/api/v1/stores/orders -H 'content-type: application/json' -d '{"menu_item_id":"giiku-sai"}'
{"id":"HKWZRTNL-3","menu_item_id":"giiku-sai","menu_name":"技育祭な いちご味","order_number":3,"status":"pending"}
```
注文状態取得API
```json
curl -X GET http://localhost:8080/api/v1/stores/orders/HKWZRTNL-2 -H 'content-type: application/json'
{"id":"HKWZRTNL-2","menu_item_id":"giiku-sai","menu_name":"技育祭な いちご味","order_number":2}
```

## Commits
- **refactor(gateway-api): update API endpoints to use /api prefix for consistency**
- **feat(gateway-api): implement detailed error handling for upstream API responses**
