### PR TITLE
swagger(gateway-api): generate chuunibyo chant with menu item

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -14,7 +14,8 @@
         "ci",
         "build",
         "chore",
-        "test"
+        "test",
+        "swagger"
       ]
     ],
     "type-case": [

--- a/backend/api/swagger/gateway-api.yml
+++ b/backend/api/swagger/gateway-api.yml
@@ -74,6 +74,43 @@ paths:
                     error: Bad Request
                     message: "menu item not found: giiku-unknown"
 
+  /api/v1/chant:
+    post:
+      summary: Generate a chuunibyo chant line using Gemini
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                menu_item_id:
+                  type: string
+                  enum: [giiku-sai, giiku-haku, giiku-ten, giiku-camp]
+            example:
+              menu_item_id: giiku-sai
+      responses:
+        "200":
+          description: Generated chant
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  chant:
+                    type: string
+              example:
+                chant: 漆黒の氷壁よ、技育祭の紋とストロベリーの朱を纏い、我が一閃にて甘美なる運命を凍結せよ——！
+        "400":
+          description: Invalid input or menu_item_id not allowed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Bad Request
+                message: "invalid menu_item_id: giiku-unknown"
+
   /api/v1/stores/orders/{orderId}:
     get:
       summary: Get order by ID

--- a/backend/services/gateway-api/internal/swagger/gateway-api.gen.go
+++ b/backend/services/gateway-api/internal/swagger/gateway-api.gen.go
@@ -10,6 +10,14 @@ const (
 	WaitingPickup OrderResponseStatus = "waitingPickup"
 )
 
+// Defines values for PostApiV1ChantJSONBodyMenuItemId.
+const (
+	GiikuCamp PostApiV1ChantJSONBodyMenuItemId = "giiku-camp"
+	GiikuHaku PostApiV1ChantJSONBodyMenuItemId = "giiku-haku"
+	GiikuSai  PostApiV1ChantJSONBodyMenuItemId = "giiku-sai"
+	GiikuTen  PostApiV1ChantJSONBodyMenuItemId = "giiku-ten"
+)
+
 // ErrorResponse defines model for ErrorResponse.
 type ErrorResponse struct {
 	Error   *string `json:"error,omitempty"`
@@ -35,10 +43,21 @@ type OrderResponse struct {
 // OrderResponseStatus defines model for OrderResponse.Status.
 type OrderResponseStatus string
 
+// PostApiV1ChantJSONBody defines parameters for PostApiV1Chant.
+type PostApiV1ChantJSONBody struct {
+	MenuItemId *PostApiV1ChantJSONBodyMenuItemId `json:"menu_item_id,omitempty"`
+}
+
+// PostApiV1ChantJSONBodyMenuItemId defines parameters for PostApiV1Chant.
+type PostApiV1ChantJSONBodyMenuItemId string
+
 // PostApiV1StoresOrdersJSONBody defines parameters for PostApiV1StoresOrders.
 type PostApiV1StoresOrdersJSONBody struct {
 	MenuItemId *string `json:"menu_item_id,omitempty"`
 }
+
+// PostApiV1ChantJSONRequestBody defines body for PostApiV1Chant for application/json ContentType.
+type PostApiV1ChantJSONRequestBody PostApiV1ChantJSONBody
 
 // PostApiV1StoresOrdersJSONRequestBody defines body for PostApiV1StoresOrders for application/json ContentType.
 type PostApiV1StoresOrdersJSONRequestBody PostApiV1StoresOrdersJSONBody


### PR DESCRIPTION
## Overview
詠唱文をgeminiが生成するエンドポイントの作成をしました

## Discussion
詠唱文生成のためのeminiのプロンプト以下の感じでいいやろか？？

```
日本語。{event} と {flavor} を必ず含め、20〜60文字、改行なし・一文のみ、記号/絵文字/引用符は禁止。荘厳で厨二病的な語彙を用い、強い動詞で締める「一言の詠唱文」を1つだけ生成せよ。出力は詠唱文のみ。

giiku-sai → {event}=技育祭, {flavor}=ストロベリー
giiku-haku → {event}=技育博, {flavor}=メロン
giiku-ten → {event}=技育展, {flavor}=ブルーハワイ
giiku-camp → {event}=技育キャンプ, {flavor}=オレンジ
```

## How To Use
どうぞmake swagger-genでもしてください

## Commits
- **swagger(gateway-api): generate chuunibyo chant with menu item**
- **feat(gateway-api): add request body structure for PostApiV1Chant**
